### PR TITLE
Allow _add-ons directory to serve content

### DIFF
--- a/cli/drivers/StatamicV1ValetDriver.php
+++ b/cli/drivers/StatamicV1ValetDriver.php
@@ -25,7 +25,7 @@ class StatamicV1ValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
-        if (strpos($uri, '/_add-ons') === 0 || strpos($uri, '/_app') === 0 || strpos($uri, '/_content') === 0 ||
+        if ( strpos($uri, '/_app') === 0 || strpos($uri, '/_content') === 0 ||
             strpos($uri, '/_cache') === 0 || strpos($uri, '/_config') === 0 || strpos($uri, '/_logs') === 0 ||
             $uri === '/admin'
         ) {


### PR DESCRIPTION
In Statamic v1 add-ons (plugins) can provide their own assets : js and css files.
So it's really unwanted to prevent the /_add-ons directory to serve static files.
I add to do this patch to allow one of my old statamic project (with custom add-ons) to run with valet.